### PR TITLE
ask the compiler to find libquadmath

### DIFF
--- a/U/modified/libs.U
+++ b/U/modified/libs.U
@@ -34,7 +34,7 @@
 ?RCS:
 ?MAKE:libs ignore_versioned_solibs libsfound libsfiles libsdirs libspath: \
 	test cat Myread Oldconfig Loc libpth package xlibpth so _a \
-	usesocks sed uselongdouble usequadmath
+	usesocks sed uselongdouble
 ?MAKE:	-pick add $@ %<
 ?S:libs:
 ?S:	This variable holds the additional libraries we want to use.
@@ -109,9 +109,6 @@ case "$usesocks" in
 esac
 case "$usecbacktrace" in
 "$define") libswanted="$libswanted bfd" ;;
-esac
-case "$usequadmath" in
-"$define") libswanted="$libswanted quadmath" ;;
 esac
 libsfound=''
 libsfiles=''

--- a/U/perl/perlxv.U
+++ b/U/perl/perlxv.U
@@ -267,17 +267,49 @@ case "$usequadmath:$i_quadmath" in
 define:define)
   nvtype="__float128"
   nvsize=16
-  case "$libs" in
-  *quadmath*) ;;
-  *) $cat <<EOM >&4
+  : libquadmath is not in the usual places, and the place
+  : changes if the compiler is upgraded.  So ask the compiler if it
+  : can find it.
+  : We do not need to save this, if it fails we abort.
+  libs="$libs -lquadmath"
+  set try
+  $cat >try.c <<EOM
+#include <quadmath.h>
+#include <stdio.h>
+int main(int argc, char *argv[]) {
+  __float128 x = 1.0;
+  if (fabsq(logq(x)) > 1e-6) {
+     fputs("quadmath is broken\n", stderr);
+     return 1;
+  }
+  puts("define");
+  return 0;
+}
+EOM
+  yyy=''
+  if eval $compile_ok; then
+      yyy=`$run ./try`
+      case "$yyy" in
+      define) ;;
+      *) cat <<EOM >&4
+
+*** You requested the use of the quadmath library, but
+*** it appears to be nonfunctional.
+*** Cannot continue, aborting.
+
+EOM
+       exit 1
+       ;;
+       esac
+  else
+      $cat <<EOM >&4
 
 *** You requested the use of the quadmath library, but you
 *** do not seem to have the quadmath library installed.
 *** Cannot continue, aborting.
 EOM
     exit 1
-    ;;
-  esac
+  fi
   ;;
 define:*) $cat <<EOM >&4
 


### PR DESCRIPTION
Based on tested code in https://github.com/tonycoz/perl5/tree/quadmath-ask-compiler

This is intended to fix https://github.com/Perl/perl5/issues/17782

Currently this requires special handling on Linux and is broken
on Cygwin, since the compiler internal library directories
aren't in the normal search path.

Rather than searching ourselves, let the compiler do it, and check
it's vaguely functional.