### PR TITLE
d_localtime_r.U - explicitly free() allocations

### DIFF
--- a/U/threads/d_localtime_r.U
+++ b/U/threads/d_localtime_r.U
@@ -132,6 +132,7 @@ REENTRANT_PROTO*)
 #endif
 int main()
 {
+    int result = 0;
     time_t t = time(0L);
     char w_tz[]="TZ" "=GMT+5",
 	 e_tz[]="TZ" "=GMT-5",
@@ -150,8 +151,10 @@ int main()
     localtime_r(&t, &tm_w);
 
     if( memcmp(&tm_e, &tm_w, sizeof(struct tm)) == 0 )
-	return 1;
-    return 0;
+	result = 1;
+
+    free(tz_e);free(tz_w);
+    return result;
 }
 EOCP
 	set try


### PR DESCRIPTION
To keep LeakSanitizer happy. See https://github.com/Perl/perl5/issues/18107 for background.