### PR TITLE
Add unit to ask whether user wants to build perl with taint support

### DIFF
--- a/U/installdirs/bin.U
+++ b/U/installdirs/bin.U
@@ -29,7 +29,7 @@
 ?RCS:
 ?MAKE:bin binexp installbin userelocatableinc initialinstalllocation: \
 	Myread Prefixit Getfile Setvar Setprefixvar Oldconfig \
-	test prefix prefixexp
+	test prefix prefixexp taint_support
 ?MAKE:	-pick add $@ %<
 ?Y:TOP
 ?D:bin=''
@@ -113,7 +113,13 @@ cat <<EOM
 Would you like to build Perl so that the installation is relocatable, so that
 library paths in @INC are determined relative to the path of the perl binary?
 This is not advised for system Perl installs, or if you need to run setid
-scripts or scripts under taint mode.
+EOM
+if test "X$taint_support" = "X$define"; then
+    echo "scripts or scripts under taint mode." >&4
+else
+    echo "scripts." >&4
+fi
+cat <<EOM
 
 If this doesn't make any sense to you, just accept the default '$dflt'.
 EOM

--- a/U/perl/taint_support.U
+++ b/U/perl/taint_support.U
@@ -1,0 +1,53 @@
+?RCS: $Id: taint_support.U,v 0RCS:
+?RCS: Copyright (c) 2022 Neil Bowers
+?RCS:
+?RCS: You may distribute under the terms of either the GNU General Public
+?RCS: License or the Artistic License, as specified in the README file.
+?RCS:
+?MAKE:taint_support: ccflags Setvar Myread
+?MAKE:	-pick add $@ %<
+?S:taint_support:
+?S:	This setting provides a mechanism for deciding whether to include
+?S:	taint support in perl.
+?S:.
+?C:HAS_TAINT_SUPPORT:
+?C:	This symbol, if defined, indicates whether taint support is available.
+?C:.
+?H:#$taint_support HAS_TAINT_SUPPORT	/**/
+?H:.
+?LINT:change ccflags
+?LINT:set taint_support
+: U/perl/taint_support.U - do we want taint support?
+case "$taint_support" in
+    $undef|false|[Nn]*)
+       dflt="n"
+       ;;
+    *)
+       dflt="y"
+       ;;
+esac
+cat >&4 <<EOM
+
+
+Perl can provide a set of special security checks, which are known
+as taint mode.  The most well-known of these is that data derived
+from outside your program should not be trusted ("is tainted")
+until you have checked it.
+
+These days there are many more security considerations, and as a result
+taint mode isn't widely used. But support for it adds a runtime overhead,
+whether or not you use it.  As a result, you can choose to build Perl
+without taint support.
+
+EOM
+rp='Do you want to build Perl with taint support?'
+. ./myread
+case "$ans" in
+$undef|false|n|N)    val="$undef"
+        ccflags="$ccflags -DSILENT_NO_TAINT_SUPPORT"
+        ;;
+*)      val="$define" ;;
+esac
+set taint_support
+eval $setvar
+


### PR DESCRIPTION
This adds a question to Configure to ask whether the user wants to build perl with or without taint support.

This adds a Configure variable `taint_support`, so to build perl without taint support, you can run:

    $ ./Configure -des -Dusedevel -Utaint_support

