### PR TITLE
Update U/perl/disparate_lc_all.U to match Perl 5.40.0

### DIFF
--- a/U/perl/disparate_lc_all.U
+++ b/U/perl/disparate_lc_all.U
@@ -61,9 +61,9 @@
 ?C:	LC_ALL_SEPARATOR, then the category given by element [1] and so on.
 ?C:.
 ?X:XXX set to 0 on non setlocale
-?H:#$d_perl_lc_all_uses_name_value_pairs PERL_LC_ALL_USES_NAME_VALUE_PAIRS
-?H:#define  PERL_LC_ALL_SEPARATOR $perl_lc_all_separator
-?H:#define  PERL_LC_ALL_CATEGORY_POSITIONS_INIT  $perl_lc_all_category_positions_init
+?H:#$d_perl_lc_all_uses_name_value_pairs PERL_LC_ALL_USES_NAME_VALUE_PAIRS  	/**/
+?H:#$d_perl_lc_all_separator  PERL_LC_ALL_SEPARATOR $perl_lc_all_separator	/**/
+?H:#$d_perl_lc_all_category_positions_init  PERL_LC_ALL_CATEGORY_POSITIONS_INIT  $perl_lc_all_category_positions_init	/**/
 ?H:.
 ?D:d_perl_lc_all_uses_name_value_pairs=$undef
 ?T:output


### PR DESCRIPTION
This assumes that the version in Perl-5.40.0-RC1 (from https://github.com/Perl/perl5/commit/0944cd7375842c8de7127f6ad0e4cbbb88a2b015 ) is correct, and that the backported version in metaconfig.git c81a29c3fd2dc505743c99d94974936e70f2ba27 had unrelated (and unwanted) changes.

I have tested that this fixes the divergence for me.

Closes: #90 